### PR TITLE
Allow AV1 streaming for ffmpeg 8

### DIFF
--- a/src/protect-stream.ts
+++ b/src/protect-stream.ts
@@ -443,8 +443,8 @@ export class ProtectStreamingDelegate implements HomebridgeStreamingDelegate {
 
     this.abTest = !this.abTest;
 
-    // FFmpeg doesn't support AV1 over RTSP yet.
-    if((this.protectCamera.ufp.videoCodec === "av1") && !useTsb) {
+    // FFmpeg 8 is required for AV1 over RTSP.
+    if((this.protectCamera.ufp.videoCodec === "av1" && ! this.platform.codecSupport.ffmpegVersion.startsWith("8.")) && !useTsb) {
 
       if(!this.hksv?.isRecording) {
 


### PR DESCRIPTION
AV1 streaming is blocked stating that ffmpeg does not support AV1 over RTSP. AV1 of RTSP was added in ffmpeg in version 8, so this is no longer true. G6 cameras (maybe others) now support "Advanced Encoding," which means AV1. I have tested this and it is working with a G6 bullet that has AV1 encoding set.

NOTE:
AV1 decode will fail on Macs that do not have AV1 hardware decode in VT. See: 
hjdhjd/homebridge-plugin-utils/issues/5/ and hjdhjd/homebridge-plugin-utils/pull/4

Resolves #1283 