### PR TITLE
Fix TypeError when contact sensor isOpened is null

### DIFF
--- a/src/devices/protect-sensor.ts
+++ b/src/devices/protect-sensor.ts
@@ -473,7 +473,7 @@ export class ProtectSensor extends ProtectDevice {
   // Get the current contact sensor information.
   private get contact(): boolean {
 
-    return this.ufp.isOpened;
+    return this.ufp.isOpened ?? false;
   }
 
   // Get the current humidity information.


### PR DESCRIPTION

ufp.isOpened is a boolean, Unifi Protect seems to sometimes return null at runtime, like for this gate sensor, unknown state.
That causes a TypeError: Cannot read properties of null (reading 'toString') in configureContactSensor. This crashes the child bridge and also the homekit warning : characteristic was supplied illegal value: null
this fix coalesces null to false.  Might want to have isOpened be boolean| null.
