### PR TITLE
Bump undici to 8.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@homebridge/plugin-ui-utils": "2.2.3",
         "ffmpeg-for-homebridge": "2.2.2",
         "homebridge-plugin-utils": "1.35.0",
-        "undici": "8.0.2",
+        "undici": "8.0.3",
         "unifi-protect": "4.29.0"
       },
       "devDependencies": {
@@ -2969,9 +2969,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.0.2.tgz",
-      "integrity": "sha512-B9MeU5wuFhkFAuNeA19K2GDFcQXZxq33fL0nRy2Aq30wdufZbyyvxW3/ChaeipXVfy/wUweZyzovQGk39+9k2w==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.0.3.tgz",
+      "integrity": "sha512-vTLEG/ceXgu/dMTQ8uNE2zgl7I7qEkx9l9tkz2H802AkgbBMvbmHMu4YqsrpGbUAMYKSQhCbmjsWMAeGu1dYXg==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"
@@ -2996,6 +2996,15 @@
       },
       "engines": {
         "node": ">=22"
+      }
+    },
+    "node_modules/unifi-protect/node_modules/undici": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.0.2.tgz",
+      "integrity": "sha512-B9MeU5wuFhkFAuNeA19K2GDFcQXZxq33fL0nRy2Aq30wdufZbyyvxW3/ChaeipXVfy/wUweZyzovQGk39+9k2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/universalify": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@homebridge/plugin-ui-utils": "2.2.3",
     "ffmpeg-for-homebridge": "2.2.2",
     "homebridge-plugin-utils": "1.35.0",
-    "undici": "8.0.2",
+    "undici": "8.0.3",
     "unifi-protect": "4.29.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This fixes an issue introduced with undici v8.0.2 causing the homebridge ring plugin to fail.
Ref: https://github.com/dgreif/ring/issues/1724 https://github.com/nodejs/undici/pull/4990